### PR TITLE
HOTFIX: Rollback a Python 3.8.3 porque la 3.8.4 está buggeada

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.8.3
 
 ADD ./requirements/prod.txt /tmp/requirements.txt
 

--- a/bin/chotuve_auth_dev/docker-compose.dev.yml
+++ b/bin/chotuve_auth_dev/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: '3.4'
 services:
     chotuve_auth:
         network_mode: host
-        image: python:3.8
+        image: python:3.8.3
         volumes:
             - ../..:/var/www/app
             - chotuve_pip_cache:/root


### PR DESCRIPTION
BUG: https://stackoverflow.com/questions/62896860/flask-sqlalchemy-error-with-setattr-to-defaultmeta